### PR TITLE
Add Assignments to _Out_ pointers for SQLAllocConnect and SQLAllocStmt

### DIFF
--- a/odbc-ipfs/core.cpp
+++ b/odbc-ipfs/core.cpp
@@ -26,6 +26,7 @@ SQLRETURN  SQL_API SQLAllocConnect(SQLHENV EnvironmentHandle,
     }
 
     dbc->env = env;
+    *ConnectionHandle = (SQLHDBC)dbc;
 
     return SQL_SUCCESS;
 }
@@ -104,6 +105,7 @@ SQLRETURN  SQL_API SQLAllocStmt(SQLHDBC ConnectionHandle,
     }
 
     stmt->dbc = dbc;
+    *StatementHandle = (SQLHSTMT)stmt;
 
     return SQL_SUCCESS;
 }


### PR DESCRIPTION
fixed error of not assigning allocated struct to _Out_